### PR TITLE
feat(exodus-extension): init Exodus client

### DIFF
--- a/wallets/exodus-extension/src/exodus.ts
+++ b/wallets/exodus-extension/src/exodus.ts
@@ -1,0 +1,9 @@
+import { preferredEndpoints } from './config';
+import { exodusExtensionInfo, ExodusExtensionWallet } from './extension';
+
+const exodusExtension = new ExodusExtensionWallet(
+  exodusExtensionInfo,
+  preferredEndpoints
+);
+
+export const wallets = [exodusExtension];

--- a/wallets/exodus-extension/src/extension/chain-wallet.ts
+++ b/wallets/exodus-extension/src/extension/chain-wallet.ts
@@ -1,0 +1,7 @@
+import { ChainRecord, ChainWalletBase, Wallet } from '@cosmos-kit/core';
+
+export class ChainExodusExtension extends ChainWalletBase {
+  constructor(walletInfo: Wallet, chainInfo: ChainRecord) {
+    super(walletInfo, chainInfo);
+  }
+}

--- a/wallets/exodus-extension/src/extension/index.ts
+++ b/wallets/exodus-extension/src/extension/index.ts
@@ -1,0 +1,3 @@
+export * from './chain-wallet';
+export * from './main-wallet';
+export * from './registry';

--- a/wallets/exodus-extension/src/extension/main-wallet.ts
+++ b/wallets/exodus-extension/src/extension/main-wallet.ts
@@ -1,0 +1,24 @@
+import { EndpointOptions, Wallet } from '@cosmos-kit/core';
+import { MainWalletBase } from '@cosmos-kit/core';
+
+import { ChainExodusExtension } from './chain-wallet';
+import { ExodusClient } from './client';
+import { getExodusFromExtension } from './utils';
+
+export class ExodusExtensionWallet extends MainWalletBase {
+  constructor(walletInfo: Wallet, preferredEndpoints?: EndpointOptions) {
+    super(walletInfo, ChainExodusExtension);
+    this.preferredEndpoints = preferredEndpoints;
+  }
+
+  async initClient() {
+    this.initingClient();
+    try {
+      const exodus = await getExodusFromExtension();
+      this.initClientDone(exodus ? new ExodusClient(exodus.cosmos) : undefined);
+    } catch (error) {
+      this.logger?.error(error);
+      this.initClientError(error);
+    }
+  }
+}

--- a/wallets/exodus-extension/src/extension/main-wallet.ts
+++ b/wallets/exodus-extension/src/extension/main-wallet.ts
@@ -15,6 +15,9 @@ export class ExodusExtensionWallet extends MainWalletBase {
     this.initingClient();
     try {
       const exodus = await getExodusFromExtension();
+      if (!exodus.cosmos) {
+        throw new Error('Exodus client does not support Cosmos provider');
+      }
       this.initClientDone(exodus ? new ExodusClient(exodus.cosmos) : undefined);
     } catch (error) {
       this.logger?.error(error);

--- a/wallets/exodus-extension/src/extension/utils.ts
+++ b/wallets/exodus-extension/src/extension/utils.ts
@@ -1,0 +1,43 @@
+import { ClientNotExistError } from '@cosmos-kit/core';
+
+import type { Exodus, ExodusWindow } from '../types';
+
+export const getExodusFromExtension: () => Promise<
+  Exodus | undefined
+> = async () => {
+  if (typeof window === 'undefined') {
+    return void 0;
+  }
+
+  const exodus = ((window as unknown) as ExodusWindow).exodus;
+
+  if (exodus) {
+    return exodus;
+  }
+
+  if (document.readyState === 'complete') {
+    if (exodus) {
+      return exodus;
+    } else {
+      throw ClientNotExistError;
+    }
+  }
+
+  return new Promise((resolve, reject) => {
+    const documentStateChange = (event: Event) => {
+      if (
+        event.target &&
+        (event.target as Document).readyState === 'complete'
+      ) {
+        if (exodus) {
+          resolve(exodus);
+        } else {
+          reject(ClientNotExistError.message);
+        }
+        document.removeEventListener('readystatechange', documentStateChange);
+      }
+    };
+
+    document.addEventListener('readystatechange', documentStateChange);
+  });
+};

--- a/wallets/exodus-extension/src/index.ts
+++ b/wallets/exodus-extension/src/index.ts
@@ -1,0 +1,3 @@
+export * from './exodus';
+export * from './extension';
+export * from './extension/client';


### PR DESCRIPTION
Tested connection flow from https://github.com/ExodusMovement/exodus-browser/tree/bulgakovk/fake-cosmos-deps with the following patch (should be applied in this repo):
```
Subject: [PATCH] refactor: throw error if `cosmos` not supported by exodus
---
Index: packages/example/pages/_app.tsx
IDEA additional info:
Subsystem: com.intellij.openapi.diff.impl.patch.CharsetEP
<+>UTF-8
===================================================================
diff --git a/packages/example/pages/_app.tsx b/packages/example/pages/_app.tsx
--- a/packages/example/pages/_app.tsx	(revision de24ed26b13f38ebd79e99621a1b3596bb756bd1)
+++ b/packages/example/pages/_app.tsx	(date 1677573371658)
@@ -12,6 +12,7 @@
 import { wallets as trustWallets } from "@cosmos-kit/trust";
 import { wallets as vectisWallets } from "@cosmos-kit/vectis";
 import { wallets as frontierWallets } from "@cosmos-kit/frontier-extension";
+import { wallets as exodusWallets } from '@cosmos-kit/exodus-extension'
 import { ChainProvider, defaultTheme } from "@cosmos-kit/react";
 import { assets, chains } from "chain-registry";
 import type { AppProps } from "next/app";
@@ -42,6 +43,7 @@
           // ...keplrWallets,
           // ...cosmostationWallets,
           ...leapWallets,
+          ...exodusWallets,
           // ...vectisWallets,
           // ...xdefiWallets,
           // ...omniWallets,

```