### PR TITLE
fix: typescript compiler errors

### DIFF
--- a/wallets/exodus-extension/src/extension/client.ts
+++ b/wallets/exodus-extension/src/extension/client.ts
@@ -7,7 +7,7 @@ import type { ExodusCosmosProvider } from '../types';
 
 export class ExodusClient implements WalletClient {
   readonly client: ExodusCosmosProvider;
-  #account;
+  private account!: AccountData;
 
   constructor(client: ExodusCosmosProvider) {
     this.client = client;
@@ -16,14 +16,14 @@ export class ExodusClient implements WalletClient {
   async getAccount(chainId: string) {
     const account = await this.client.connect({ chainId });
 
-    this.#account = account;
+    this.account = account;
 
     return account;
   }
 
   async getOfflineSigner() {
     return {
-      getAccounts: async (): Promise<AccountData[]> => [this.#account],
+      getAccounts: async (): Promise<AccountData[]> => [this.account],
       signDirect: async (
         signer: string,
         signDoc: SignDoc
@@ -37,8 +37,8 @@ export class ExodusClient implements WalletClient {
           signed: signDoc,
           signature: {
             pub_key: {
-              type: this.#account.algo,
-              value: this.#account.publicKey,
+              type: this.account.algo,
+              value: this.account.pubkey,
             },
             signature,
           },

--- a/wallets/exodus-extension/src/extension/main-wallet.ts
+++ b/wallets/exodus-extension/src/extension/main-wallet.ts
@@ -15,11 +15,11 @@ export class ExodusExtensionWallet extends MainWalletBase {
     this.initingClient();
     try {
       const exodus = await getExodusFromExtension();
-      if (!exodus.cosmos) {
+      if (exodus?.cosmos) {
         throw new Error('Exodus client does not support Cosmos provider');
       }
       this.initClientDone(exodus ? new ExodusClient(exodus.cosmos) : undefined);
-    } catch (error) {
+    } catch (error: any) {
       this.logger?.error(error);
       this.initClientError(error);
     }

--- a/wallets/exodus-extension/src/types.ts
+++ b/wallets/exodus-extension/src/types.ts
@@ -1,3 +1,5 @@
+import type { AccountData } from '@cosmjs/proto-signing';
+
 type Chain = string;
 
 export interface Account {
@@ -16,7 +18,7 @@ interface Transaction {
 }
 
 export interface ExodusCosmosProvider {
-  connect: (options: ConnectionOptions) => Promise<Account>;
+  connect: (options: ConnectionOptions) => Promise<AccountData>;
   signTransaction: (transaction: Transaction) => Promise<{ signature: string }>;
 }
 


### PR DESCRIPTION
noticed during `yarn build` in the example that the TS compiler threw some errors.

for the `account` field, we should use the `private` modifier to be in parity with the rest of the repo.  Also, we are asking for additional fields outside of our own `Account` type so `AccountData` might be more appropriate.

Also fixes a couple of TS errors in `main-wallet.ts`

